### PR TITLE
Bug fix

### DIFF
--- a/NAMESPACE
+++ b/NAMESPACE
@@ -1,1 +1,2 @@
 exportPattern("^[[:alpha:]]+")
+importFrom(survival,Surv)

--- a/R/SL_wrappers.R
+++ b/R/SL_wrappers.R
@@ -201,7 +201,7 @@ predict.survSL.coxph <- function(object, newX, new.times, ...) {
 survSL.rfsrc <- function(time, event, X, newX, new.times, obsWeights, id, ...) {
   data <- data.frame(time, event)
   data <- cbind(data, X)
-  fit.rfsrc <- randomForestSRC::rfsrc(survival::Surv(time, event) ~ ., data=data, importance = FALSE, case.wt = obsWeights, ...)
+  fit.rfsrc <- randomForestSRC::rfsrc(Surv(time, event) ~ ., data=data, importance = FALSE, case.wt = obsWeights, ...)
   survs <- predict(fit.rfsrc, newdata=newX, importance='none')$survival
   pred <- t(sapply(1:nrow(survs), function(i) {
     stats::approx(c(0,fit.rfsrc$time.interest), c(1,survs[i,]), method='constant', xout = new.times, rule = 2)$y

--- a/R/SL_wrappers.R
+++ b/R/SL_wrappers.R
@@ -250,6 +250,9 @@ predict.survSL.rfsrc <- function(object, newX, new.times, ...) {
 
 
 survSL.gam <- function(time, event, X, newX, new.times, cts.num = 5, ...) {
+  
+  if (any(round(list(...)[["obsWeights"]],8)!=1))
+    warning("Argument 'obsWeights' is ignored by the 'gam' library algorithm")
   if ("gam" %in% loadedNamespaces())
     warning("mgcv and gam packages are both in use. You might see an error because both packages use the same function names.")
   cts.x <- apply(X, 2, function(x) (length(unique(x)) > cts.num))


### PR DESCRIPTION
Hi, Ted! Another student of Marco's (Charlie Wolock) discovered a bug in the randomForestSRC package that affects survSuperLearner. Essentially, writing survival::Surv() instead of Surv() causes errors with formula parsing (even though it shouldn't). To compensate for this, I removed the survival:: prefix for the random forest algorithm only.